### PR TITLE
Initialize notcurses_options struct

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,19 +19,18 @@ if(NOT TARGET uninstall)
 endif()
 
 # Makefile generation
-if(CMAKE_BUILD_TYPE STREQUAL Debug)
-  set(DEBUG_OPTIONS -g -O0)
-else()
-  set(DEBUG_OPTIONS -O2)
-endif()
+string(APPEND CMAKE_C_FLAGS_DEBUG " -O0")
+string(APPEND CMAKE_CXX_FLAGS_DEBUG " -O0")
 # ^ Shameless notcurses copypasta
+
+find_package(notcurses 1.3.4 REQUIRED)
 
 add_library(libnotcurses SHARED IMPORTED)
 set_target_properties(libnotcurses PROPERTIES
 	IMPORTED_LOCATION "/usr/local/lib")
 
 add_executable(ncmatrix ./src/main.cxx ./src/planepool.cxx ./src/planepoolelement.cxx ./src/ncm_utils.cxx)
-target_link_libraries(ncmatrix notcurses)
+target_link_libraries(ncmatrix ${notcurses_LIBRARIES})
 set_target_properties(ncmatrix PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/")
 

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -43,13 +43,7 @@ int main(int argc, char **argv)
 	FILE* rfp = NULL;
 	
 	// setting notcurses_options
-	notcurses_options opts;
-	opts.termtype = NULL;
-	opts.inhibit_alternate_screen = false;
-	opts.retain_cursor = false;
-	opts.suppress_banner = true;
-	opts.no_quit_sighandlers = false;
-	opts.no_winch_sighandler = false;
+	notcurses_options opts{};
 	opts.renderfp = rfp;
 	
 	// Initialising notcurses


### PR DESCRIPTION
The `notcurses_options` struct needs be zeroed out in its entirety. This construction both future-proofs us, and remedies current use of uninitialized memory (as of 1.3.5-pre, there are `loglevel`, `margin_X`, and `flags`). Closes #7 .